### PR TITLE
Add path of cli.py to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 build: clean
 	@( \
        . $(WORKSPACE)/.venv/bin/activate; \
-	   pyinstaller --name aws-auto-inventory-$(OS)-$(ARCH) --clean --onefile --hidden-import cmath --log-level=DEBUG cli.py 2> build.txt; \
+	   pyinstaller --name aws-auto-inventory-$(OS)-$(ARCH) --clean --onefile --hidden-import cmath --log-level=DEBUG app/cli.py 2> build.txt; \
     )
 
 .PHONY: run


### PR DESCRIPTION
Fixes https://github.com/aws-samples/aws-auto-inventory/issues/19

*Description of changes:*
Add path of cli.py file in Makefile since `make` can't find it


```
~/d/aws-auto-inventory-0.2.0 $ make init build            
python3 -m venv .venv
Requirement already satisfied: pip in ./.venv/lib/python3.9/site-packages (22.3.1)
Requirement already satisfied: pyinstaller in ./.venv/lib/python3.9/site-packages (5.3)
Collecting pyinstaller
  Using cached pyinstaller-5.7.0-py3-none-macosx_10_13_universal2.whl (923 kB)
Requirement already satisfied: setuptools>=42.0.0 in ./.venv/lib/python3.9/site-packages (from pyinstaller) (58.1.0)
Requirement already satisfied: pyinstaller-hooks-contrib>=2021.4 in ./.venv/lib/python3.9/site-packages (from pyinstaller) (2022.8)
Requirement already satisfied: altgraph in ./.venv/lib/python3.9/site-packages (from pyinstaller) (0.17.2)
Requirement already satisfied: macholib>=1.8 in ./.venv/lib/python3.9/site-packages (from pyinstaller) (1.16.2)
Installing collected packages: pyinstaller
  Attempting uninstall: pyinstaller
    Found existing installation: pyinstaller 5.3
    Uninstalling pyinstaller-5.3:
      Successfully uninstalled pyinstaller-5.3
Successfully installed pyinstaller-5.7.0
Requirement already satisfied: altgraph==0.17.2 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 1)) (0.17.2)
Requirement already satisfied: astroid==2.11.7 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 2)) (2.11.7)
Requirement already satisfied: boto3==1.24.50 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 3)) (1.24.50)
Requirement already satisfied: botocore==1.27.50 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 4)) (1.27.50)
Requirement already satisfied: cfgv==3.3.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 5)) (3.3.1)
Requirement already satisfied: confuse==2.0.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 6)) (2.0.0)
Requirement already satisfied: dill==0.3.5.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 7)) (0.3.5.1)
Requirement already satisfied: distlib==0.3.5 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 8)) (0.3.5)
Requirement already satisfied: et-xmlfile==1.1.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 9)) (1.1.0)
Requirement already satisfied: filelock==3.8.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 10)) (3.8.0)
Requirement already satisfied: identify==2.5.3 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 11)) (2.5.3)
Requirement already satisfied: isort==5.10.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 12)) (5.10.1)
Requirement already satisfied: jmespath==1.0.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 13)) (1.0.1)
Requirement already satisfied: lazy-object-proxy==1.7.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 14)) (1.7.1)
Requirement already satisfied: mccabe==0.7.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 15)) (0.7.0)
Requirement already satisfied: nodeenv==1.7.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 16)) (1.7.0)
Requirement already satisfied: numpy==1.23.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 17)) (1.23.1)
Requirement already satisfied: openpyxl==3.0.10 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 18)) (3.0.10)
Requirement already satisfied: pandas==1.4.3 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 19)) (1.4.3)
Requirement already satisfied: platformdirs==2.5.2 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 20)) (2.5.2)
Requirement already satisfied: pre-commit==2.20.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 21)) (2.20.0)
Collecting pyinstaller==5.3
  Using cached pyinstaller-5.3-py3-none-macosx_10_13_universal2.whl (829 kB)
Requirement already satisfied: pyinstaller-hooks-contrib==2022.8 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 23)) (2022.8)
Requirement already satisfied: pylint==2.14.5 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 24)) (2.14.5)
Requirement already satisfied: python-dateutil==2.8.2 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 25)) (2.8.2)
Requirement already satisfied: pytz==2022.2 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 26)) (2022.2)
Requirement already satisfied: PyYAML==6.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 27)) (6.0)
Requirement already satisfied: s3transfer==0.6.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 28)) (0.6.0)
Requirement already satisfied: six==1.16.0 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 29)) (1.16.0)
Requirement already satisfied: toml==0.10.2 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 30)) (0.10.2)
Requirement already satisfied: tomli==2.0.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 31)) (2.0.1)
Requirement already satisfied: tomlkit==0.11.3 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 32)) (0.11.3)
Requirement already satisfied: urllib3==1.26.11 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 33)) (1.26.11)
Requirement already satisfied: virtualenv==20.16.3 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 34)) (20.16.3)
Requirement already satisfied: wrapt==1.14.1 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 35)) (1.14.1)
Requirement already satisfied: XlsxWriter==3.0.3 in ./.venv/lib/python3.9/site-packages (from -r requirements.txt (line 36)) (3.0.3)
Requirement already satisfied: typing-extensions>=3.10 in ./.venv/lib/python3.9/site-packages (from astroid==2.11.7->-r requirements.txt (line 2)) (4.4.0)
Requirement already satisfied: setuptools>=20.0 in ./.venv/lib/python3.9/site-packages (from astroid==2.11.7->-r requirements.txt (line 2)) (58.1.0)
Requirement already satisfied: macholib>=1.8 in ./.venv/lib/python3.9/site-packages (from pyinstaller==5.3->-r requirements.txt (line 22)) (1.16.2)
Installing collected packages: pyinstaller
  Attempting uninstall: pyinstaller
    Found existing installation: pyinstaller 5.7.0
    Uninstalling pyinstaller-5.7.0:
      Successfully uninstalled pyinstaller-5.7.0
Successfully installed pyinstaller-5.3
~/d/aws-auto-inventory-0.2.0 $
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
