### PR TITLE
Fix/issue 52

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
 #     - id: flake8
 #       args: ['--ignore=E501']
 - repo: https://github.com/jendrikseipp/vulture
-  rev: 'v2.7'  # or any later Vulture version
+  rev: 'v2.9.1'  # or any later Vulture version
   hooks:
     - id: vulture
       args: ['scan.py', ]

--- a/scan.py
+++ b/scan.py
@@ -13,8 +13,8 @@ import traceback
 from datetime import datetime
 import requests
 
-# Define the timestamp as a string, which will be the same throughout the execution of the script.
-timestamp = datetime.now().isoformat(timespec="minutes")
+# accomodate windows and unix path
+timestamp = datetime.now().isoformat(timespec="minutes").replace(":", "-")
 
 
 def get_json_from_url(url):
@@ -314,7 +314,10 @@ def main(
                 results.extend(region_results)
                 for service_result in region_results:
                     directory = os.path.join(output_dir, timestamp, region)
-                    os.makedirs(directory, exist_ok=True)
+                    try:
+                        os.makedirs(directory, exist_ok=True)
+                    except NotADirectoryError:
+                        log.error("Invalid directory name: %s", directory)
                     with open(
                         os.path.join(directory, f"{service_result['service']}.json"),
                         "w",


### PR DESCRIPTION
## 🧠 Pull Request

### Changes

Fix the cration of a directory with a name that contains characters (: in this case) not allowed in directory names on Windows. The problem likely arises from using a timestamp with disallowed characters as part of the folder name.

### Type of change

* Bug fix (non-breaking change which fixes an issue)

## Why

Issue #52 