### PR TITLE
Include function name in service data return and in output file name

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -163,7 +163,11 @@ def _get_service_data(session, region_name, service, log, max_retries, retry_del
         region_name,
         response,
     )
-    return {"region": region_name, "service": service["service"], "result": response}
+    return {
+        "region": region_name,
+        "service": service["service"],
+        "function": service["function"],
+        "result": response}
 
 
 def process_region(
@@ -319,7 +323,7 @@ def main(
                     except NotADirectoryError:
                         log.error("Invalid directory name: %s", directory)
                     with open(
-                        os.path.join(directory, f"{service_result['service']}.json"),
+                        os.path.join(directory, f"{service_result['service']}-{service_result['function']}.json"),
                         "w",
                     ) as f:
                         json.dump(service_result["result"], f, cls=DateTimeEncoder)


### PR DESCRIPTION
## 🧠 Pull Request

### Changes

<!--  Fix for Issue 57 -->

### Type of change

<!--
* Bug fix (non-breaking change which fixes an issue)
-->

## Why

<!-- Need to have both service name/function name as part JSON output file to prevent loss of data -->

## How (Optional)

<!-- 
- Include additional key/value return in _get_service_data function
- Use both service name/function name in main function when opening output JSON file
- -->

## Checklist

<!-- Have you done all of these things?  -->
<!-- to check an item, place an "x" in the box like so: "- [x] Automated tests" -->

-[x] Manually tested on my desktop
- [ ] Jest unit tests (as needed)
- [ ] Integration tests (as needed)
- [ ] Storybook stories (as needed)
- [ ] Run storybook locally
- [ ] Acceptance Criteria met
- [ ] Screenshot added to Summary for UI ticket
- [ ] Check test coverage of new or updated components (Reduce Banlist)

<!-- Also consider:
* Issue ref: https://github.com/aws-samples/aws-auto-inventory/issues/57
* A reference to a related issue, if any.
* @mentions of the person or team responsible for reviewing proposed changes.
* Label the pull request accordingly as `enhancement`, `bug`, etc.
-->
