### PR TITLE
chore: OSS maintenance — security reporting, Dependabot, CODEOWNERS, CodeQL v3

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS for aws-samples/aws-auto-inventory
+#
+# Lines starting with `#` are comments. Each non-comment line is a glob
+# pattern followed by one or more GitHub usernames or team names. The last
+# matching pattern wins. See:
+# https://docs.github.com/en/repositories/managing-your-repositories-settings-and-security/customizing-your-repository/about-code-owners
+#
+# Owners listed here are determined best-effort from `git log` (top
+# committers). Please open a PR if you should be added or removed.
+
+# Default owner for everything in the repo.
+*       @valter-silva-au
+
+# CI / repo metadata changes benefit from a second pair of eyes.
+/.github/                @valter-silva-au
+/SECURITY.md             @valter-silva-au
+/CODEOWNERS              @valter-silva-au

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "python"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -54,7 +54,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -68,4 +68,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,7 @@
-## Security
+## Reporting a Vulnerability
 
-We take the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations.
-If you believe you have found a security vulnerability in any AWS-owned repository, please raise an issue.
+If you discover a potential security issue in this project, we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/) or directly via email to [aws-security@amazon.com](mailto:aws-security@amazon.com).
 
-Thank you!
+Please do **not** create a public GitHub issue for security vulnerabilities.
+
+The vulnerability reporting page also contains AWS Security's PGP key, which you may use to encrypt sensitive disclosures.


### PR DESCRIPTION
## Summary

Routine OSS-hygiene hardening from a maintenance audit.

- **`docs(security)` (HIGH)** — `SECURITY.md` previously instructed reporters to "raise an issue" for security vulnerabilities, a public-disclosure anti-pattern. Replaced with the canonical AWS vulnerability-reporting guidance (vulnerability reporting page + aws-security@amazon.com) and an explicit "do not open a public issue" note.
- **`build(deps)`** — `.github/dependabot.yml`: weekly Dependabot version + security updates for `pip` and `github-actions`. (GitHub currently reports 2 high-severity dependency alerts on the default branch — this enables ongoing automated updates.)
- **`chore`** — `.github/CODEOWNERS`: default owner plus guarded patterns for `.github/`, SECURITY.md, and CODEOWNERS.
- **`ci`** — CodeQL `init`/`autobuild`/`analyze` upgraded v2 → v3 (v2 runs on the retired Node 16 runner) and `actions/checkout` v3 → v4, keeping the repo's floating-tag convention.

## Checklist

- [x] SECURITY.md uses canonical AWS vuln reporting
- [x] Dependabot — pip + github-actions
- [x] CODEOWNERS added
- [x] CodeQL action v2 → v3 (deprecation fix)

No branch protections or security settings were changed. No application code modified.
