### PR TITLE
docs: overhaul documentation to AWS style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,201 +1,203 @@
 # AWS Auto Inventory
 
-A tool for scanning AWS services across regions and accounts to collect resource information.
+A command-line tool that scans AWS services across regions and accounts and writes the results to JSON files.
+
+## Overview
+
+AWS Auto Inventory builds a resource inventory by calling AWS API operations that you define in a scan file, then saving each response as JSON. You control which services, API functions, parameters, and regions are scanned. The tool runs regions and services concurrently and retries throttled or transient API calls with exponential backoff.
+
+You use AWS Auto Inventory to collect a point-in-time snapshot of resources for auditing, reporting, or migration planning. It reads your AWS credentials through the standard boto3 credential chain, so it works the same way the AWS Command Line Interface (AWS CLI) does.
+
+The repository contains two entry points:
+
+- **`scan.py`** — the supported command-line scanner. It reads a JSON scan file (a list of API calls), writes JSON output, and can scan every account in an AWS Organization. This is the tool described in this README.
+- **`aws_auto_inventory` package** (the `aws-auto-inventory` console script) — an in-progress rewrite that adds YAML configuration, a Pydantic-validated `inventories`/`sheets` schema, and Excel output. The output module is not yet present in the package, so this console script does not produce output today. Use `scan.py` for working scans. See [Architecture](aws-auto-inventory-unified-architecture.md) for the design of the rewrite.
 
 ## Features
 
-- **Multi-format Configuration**: Support for both YAML and JSON configuration formats
-- **Multi-format Output**: Generate both JSON and Excel outputs
-- **Multi-threading**: Concurrent scanning of regions and services for faster results
-- **Organization Scanning**: Scan resources across all accounts in an AWS Organization
-- **Robust Error Handling**: Retry logic for API throttling and transient errors
-- **Flexible Filtering**: Filter resources by tags, IDs, and other attributes
-- **Data Transformation**: Transform data for better analysis, including transposition in Excel
-- **Binary Data Support**: Proper handling of binary data (bytes) returned by AWS APIs
+- Scans any boto3 service and API function you list in a scan file.
+- Scans multiple AWS Regions concurrently. If you do not pass regions, it scans every Region your account can reach.
+- Extracts a specific part of each API response by key name or by `jq` filter.
+- Retries throttled and transient API errors with exponential backoff.
+- Scans every active account in an AWS Organization by assuming a role in each account.
+- Writes one JSON file per service and function, organized by Region and a run timestamp.
+
+## Prerequisites
+
+- Python 3.8 or later.
+- AWS credentials available through the standard credential chain (environment variables, a shared credentials file, or an Amazon EC2 instance profile).
+- AWS Identity and Access Management (IAM) permissions for the API operations you scan, plus `sts:GetCallerIdentity`. Organization scans also require `organizations:ListAccounts` on the management account and `sts:AssumeRole` for the role you assume in each member account.
+- The `boto3`, `requests`, and `jq` Python packages. `scan.py` imports all three. The `jq` package needs the `jq` C library and a compiler available at install time.
 
 ## Installation
 
-### From PyPI
-
-```bash
-pip install aws-auto-inventory
-```
-
-### From Source
+Clone the repository and install the dependencies that `scan.py` requires.
 
 ```bash
 git clone https://github.com/aws-samples/aws-auto-inventory.git
 cd aws-auto-inventory
-pip install -e .
+pip install boto3 requests jq
 ```
+
+> **Note:** `requirements.txt` and `setup.py` target the in-progress `aws_auto_inventory` package, not `scan.py`. `scan.py` also imports `requests`, which is not listed there. Install `boto3`, `requests`, and `jq` as shown to run `scan.py`.
+
+## Getting started
+
+This example scans your Amazon Simple Storage Service (Amazon S3) buckets in one Region.
+
+1. Create a scan file named `s3.json` that lists the API call to make.
+
+   ```json
+   [
+     {
+       "service": "s3",
+       "function": "list_buckets",
+       "result_key": "Buckets"
+     }
+   ]
+   ```
+
+2. Run the scan against `us-east-1`.
+
+   ```bash
+   python scan.py --scan s3.json --regions us-east-1 --output_dir output
+   ```
+
+3. The tool prints the identity it authenticated as, the elapsed time, and where it stored the results.
+
+   ```text
+   Authenticated as: arn:aws:iam::123456789012:user/example
+   Total elapsed time for scanning: 0h:0m:3s
+   Result stored in  output/2026-06-07T12-30
+   ```
+
+4. Find the JSON output under the timestamped Region directory.
+
+   ```text
+   output/2026-06-07T12-30/us-east-1/s3-list_buckets.json
+   ```
+
+A log file for each run is written to the output directory as `aws_resources_<timestamp>.log`.
 
 ## Usage
 
-### Basic Usage
+Run `scan.py` with a scan file and, optionally, a list of Regions.
 
 ```bash
-aws-auto-inventory --config examples/config_example.yaml --output-dir output --format both
+python scan.py --scan examples/scan.json --regions us-east-1 us-west-2 --output_dir output
 ```
 
-### Command-line Options
+Sample scan files are provided under `scan/sample/`. `scan/sample/all_services.json` lists every readable API function across all services. Per-service files are under `scan/sample/services/`.
 
+### Command-line options
+
+| Flag | Description | Default |
+| --- | --- | --- |
+| `-s`, `--scan` | Path or URL to the JSON scan file. Required. | — |
+| `-r`, `--regions` | Space-separated list of Regions to scan. | All reachable Regions |
+| `-o`, `--output_dir` | Directory for results and logs. | `output` |
+| `-l`, `--log_level` | Logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`. | `INFO` |
+| `--max-retries` | Maximum retries per API call. | `3` |
+| `--retry-delay` | Base delay in seconds for retry backoff. | `2` |
+| `--concurrent-regions` | Number of Regions to scan at once. | All at once |
+| `--concurrent-services` | Number of services to scan at once per Region. | All at once |
+| `--organization-scan` | Scan every active account in the AWS Organization. | Off |
+| `--org-role-name` | IAM role to assume in each member account. | `OrganizationAccountAccessRole` |
+
+### Scan an AWS Organization
+
+To scan every active account in your AWS Organization, run the scanner from the management account with `--organization-scan`. The tool lists all active accounts with `organizations:ListAccounts`, assumes the named role in each account, and runs the scan there.
+
+```bash
+python scan.py --scan examples/scan.json --organization-scan --org-role-name OrganizationAccountAccessRole
 ```
-usage: aws-auto-inventory [-h] -c CONFIG [-o OUTPUT_DIR] [-f {json,excel,both}]
-                         [--max-regions MAX_REGIONS] [--max-services MAX_SERVICES]
-                         [--max-retries MAX_RETRIES] [--retry-delay RETRY_DELAY]
-                         [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}]
-                         [--validate-only]
 
-AWS Auto Inventory - Scan AWS resources and generate inventory
+The organization scan lists accounts directly; it does not traverse organizational units (OUs). Results for each account are written under `output/organization-<timestamp>/<account-id>/`, with an `accounts.json` summary at the top level.
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -c CONFIG, --config CONFIG
-                        Path to configuration file (YAML or JSON)
-  -o OUTPUT_DIR, --output-dir OUTPUT_DIR
-                        Directory to store output files (default: output)
-  -f {json,excel,both}, --format {json,excel,both}
-                        Output format (default: json)
-  --max-regions MAX_REGIONS
-                        Maximum number of regions to scan concurrently
-  --max-services MAX_SERVICES
-                        Maximum number of services to scan concurrently per region
-  --max-retries MAX_RETRIES
-                        Maximum number of retries for API calls (default: 3)
-  --retry-delay RETRY_DELAY
-                        Base delay in seconds between retries (default: 2)
-  --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
-                        Logging level (default: INFO)
-  --validate-only       Validate configuration and exit without scanning
+### Load a scan file from a URL
+
+You can pass a URL instead of a local path. The tool fetches the JSON over HTTP or HTTPS.
+
+```bash
+python scan.py --scan https://example.com/scans/core.json --regions us-east-1
 ```
 
 ## Configuration
 
-AWS Auto Inventory uses a configuration file to define what resources to scan. The configuration file can be in either YAML or JSON format.
+A scan file is a JSON array. Each element describes one API call.
 
-### Example Configuration (YAML)
+| Field | Required | Description |
+| --- | --- | --- |
+| `service` | Yes | The boto3 service name, such as `ec2` or `s3`. |
+| `function` | Yes | The boto3 client method to call, such as `describe_instances`. |
+| `result_key` | No | Extracts part of the response. A plain key (such as `Reservations`) reads that top-level field. A value that starts with `.` is evaluated as a `jq` filter against the full response. If omitted, the full response is returned with `ResponseMetadata` removed. |
+| `parameters` | No | A map of keyword arguments passed to the API call. |
 
-```yaml
-inventories:
-  - name: my-aws-inventory
-    aws:
-      profile: default
-      region:
-        - us-east-1
-        - us-west-2
-      organization: false
-    excel:
-      transpose: true
-    sheets:
-      - name: EC2Instances
-        service: ec2
-        function: describe_instances
-        result_key: Reservations
-        parameters:
-          Filters:
-            - Name: instance-state-name
-              Values:
-                - running
-      - name: S3Buckets
-        service: s3
-        function: list_buckets
-        result_key: Buckets
-```
-
-### Example Configuration (JSON)
+The following scan file lists running Amazon Elastic Compute Cloud (Amazon EC2) instances and all S3 buckets.
 
 ```json
-{
-  "inventories": [
-    {
-      "name": "my-aws-inventory",
-      "aws": {
-        "profile": "default",
-        "region": ["us-east-1", "us-west-2"],
-        "organization": false
-      },
-      "excel": {
-        "transpose": true
-      },
-      "sheets": [
+[
+  {
+    "service": "ec2",
+    "function": "describe_instances",
+    "result_key": "Reservations",
+    "parameters": {
+      "Filters": [
         {
-          "name": "EC2Instances",
-          "service": "ec2",
-          "function": "describe_instances",
-          "result_key": "Reservations",
-          "parameters": {
-            "Filters": [
-              {
-                "Name": "instance-state-name",
-                "Values": ["running"]
-              }
-            ]
-          }
-        },
-        {
-          "name": "S3Buckets",
-          "service": "s3",
-          "function": "list_buckets",
-          "result_key": "Buckets"
+          "Name": "instance-state-name",
+          "Values": ["running"]
         }
       ]
     }
-  ]
-}
+  },
+  {
+    "service": "s3",
+    "function": "list_buckets",
+    "result_key": "Buckets"
+  }
+]
 ```
 
-### Organization Scanning
+### Generate a scan file for every service
 
-To scan resources across all accounts in an AWS Organization, set `organization: true` in the configuration:
+`scan_builder.py` writes a scan file for every available service into `scan/sample/services/`, listing each `get`, `describe`, and `list` function. Run it with AWS credentials configured.
 
-```yaml
-inventories:
-  - name: organization-wide
-    aws:
-      profile: management
-      region:
-        - us-east-1
-        - us-west-2
-      organization: true
-      role_name: OrganizationAccountAccessRole
-    sheets:
-      # ... sheets configuration ...
+```bash
+python scan_builder.py
 ```
+
+## Credentials
+
+AWS Auto Inventory uses the standard boto3 credential chain, in this order:
+
+1. Environment variables.
+2. The shared credentials file (`~/.aws/credentials`).
+3. An IAM role attached to an Amazon EC2 instance or container.
+
+Before scanning, the tool calls `sts:GetCallerIdentity` and prints the authenticated principal. If the call fails, the scan stops.
 
 ## Output
 
-AWS Auto Inventory generates output files in the specified output directory:
+For a single-account scan, the tool writes one JSON file per service and function:
 
-- **JSON Output**: JSON files for each service in each region
-- **Excel Output**: Excel spreadsheets with one sheet per service
+```text
+output/<timestamp>/<region>/<service>-<function>.json
+```
 
-### Handling of Binary Data
+`datetime` values in API responses are serialized as ISO 8601 strings. Binary values returned by some API operations (for example, `cloudtrail:ListPublicKeys`) are not specially encoded and can cause a serialization error on the affected service. This affects scans that include such operations, including some scans in AWS GovCloud (US).
 
-Some AWS APIs (like CloudTrail.Client.list_public_keys) return binary data as bytes. AWS Auto Inventory handles this data as follows:
+## Architecture
 
-- In JSON output: Binary data is encoded as base64 and stored in a special format: `{"__bytes_b64__": "base64-encoded-string"}`
-- In Excel output: Binary data is converted to a string in the format: `[BYTES: base64-encoded-string]`
+For the design of the in-progress `aws_auto_inventory` package rewrite — configuration layer, scan engine, and output processor — see [Architecture](aws-auto-inventory-unified-architecture.md).
 
-This ensures that all data can be properly serialized and deserialized without errors.
+## Contributing
 
-## Examples
+See [Contributing](CONTRIBUTING.md) for how to propose changes.
 
-Example configuration files are provided in the `examples` directory:
+## Security
 
-- `config_example.yaml`: Basic YAML configuration
-- `config_example.json`: Basic JSON configuration
-- `config_organization_example.yaml`: Configuration for organization-wide scanning
-
-## AWS Credentials
-
-AWS Auto Inventory uses the standard AWS credential providers:
-
-1. Environment variables
-2. Shared credential file (~/.aws/credentials)
-3. AWS IAM Instance Profile (if running on an EC2 instance)
-
-You can specify a profile name in the configuration file to use a specific profile from your credentials file.
+See [Security](SECURITY.md) for how to report a vulnerability.
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the LICENSE file for details.
+This project is licensed under the Apache License 2.0. See [LICENSE](LICENSE) for details.

--- a/aws-auto-inventory-unified-architecture.md
+++ b/aws-auto-inventory-unified-architecture.md
@@ -1,665 +1,122 @@
-# AWS Auto Inventory: Unified Architecture Plan
+# Architecture
 
-## Table of Contents
-1. [Current State Analysis](#current-state-analysis)
-2. [Unified Architecture Design](#unified-architecture-design)
-3. [Detailed Implementation Strategy](#detailed-implementation-strategy)
-4. [Implementation Details](#implementation-details)
-5. [Potential Challenges and Mitigation Strategies](#potential-challenges-and-mitigation-strategies)
-6. [Next Steps](#next-steps)
+This document describes how AWS Auto Inventory is structured: the supported `scan.py` scanner that ships today, and the in-progress `aws_auto_inventory` package that is being built to replace it.
 
-## Current State Analysis
+## Overview
 
-### JSON-based Implementation (Current Codebase)
-- **Strengths**: 
-  - Multi-threading for concurrent scanning of regions and services
-  - Organization-wide scanning across multiple AWS accounts
-  - Robust API call retry logic and throttling handling
-  - Simple JSON configuration format
-  - Direct AWS API access through boto3
-  - Modular design with separate components for scanning and organization handling
+The repository holds two implementations at different stages of maturity.
 
-### Excel-based Implementation (Described in habits.yaml)
-- **Strengths**:
-  - Excel spreadsheet output (more user-friendly for analysis)
-  - YAML configuration format (more human-readable)
-  - Advanced filtering capabilities (by tags, VPC, subnets, etc.)
-  - Support for multiple AWS accounts through profiles
-  - Transposable data in Excel output
+- **`scan.py`** is the supported scanner. It reads a JSON scan file (a list of API calls), runs the calls concurrently across Regions and services, and writes one JSON file per service and function. `organization_scanner.py` extends it to scan every account in an AWS Organization.
+- **`aws_auto_inventory`** is a package that reorganizes the same scanning logic behind a layered design with YAML and JSON configuration, Pydantic validation, and planned Excel output. The package is incomplete: its command-line interface (CLI) imports an output module that does not yet exist, so the `aws-auto-inventory` console script cannot produce output today.
 
-## Unified Architecture Design
+Both implementations call AWS APIs through boto3 and use the same retry and result-extraction model.
 
-### Architecture Overview
+## Supported implementation: scan.py
 
-```mermaid
-graph TD
-    A[Configuration Layer] --> B[Core Scanning Engine]
-    B --> C[Output Processor]
-    
-    subgraph "Configuration Layer"
-        A1[YAML Config Parser]
-        A2[JSON Config Parser]
-        A3[Config Validator]
-    end
-    
-    subgraph "Core Scanning Engine"
-        B1[AWS API Client]
-        B2[Multi-threading Manager]
-        B3[Organization Scanner]
-        B4[Retry & Throttling Handler]
-    end
-    
-    subgraph "Output Processor"
-        C1[JSON Output Generator]
-        C2[Excel Output Generator]
-        C3[Data Transformer]
-    end
-    
-    A1 --> A3
-    A2 --> A3
-    A3 --> B
-    B --> B1
-    B --> B2
-    B --> B3
-    B --> B4
-    B --> C
-    C --> C1
-    C --> C2
-    C --> C3
+### Components
+
+| Component | File | Responsibility |
+| --- | --- | --- |
+| CLI and orchestrator | `scan.py` (`main`) | Parses arguments, loads the scan file, resolves Regions, and coordinates concurrent scanning. |
+| Service caller | `scan.py` (`_get_service_data`, `api_call_with_retry`) | Calls one API function for one service in one Region, with retry and result extraction. |
+| Region worker | `scan.py` (`process_region`) | Scans all configured services within a single Region. |
+| Credential check | `scan.py` (`check_aws_credentials`) | Calls `sts:GetCallerIdentity` and prints the authenticated principal before scanning. |
+| Organization scanner | `organization_scanner.py` | Lists organization accounts, assumes a role in each, and runs `scan.py`'s `main` against each account. |
+| Scan-file builder | `scan_builder.py` | Generates per-service scan files listing every `get`, `describe`, and `list` function. |
+
+### Data flow
+
+```text
+scan file (JSON list)        AWS credentials (boto3 chain)
+        |                              |
+        v                              v
+   main(): load scan file, verify credentials, resolve Regions
+        |
+        v
+   ThreadPoolExecutor over Regions  (--concurrent-regions)
+        |
+        v
+   process_region(): ThreadPoolExecutor over services  (--concurrent-services)
+        |
+        v
+   _get_service_data(): boto3 client.<function>(**parameters)
+        |  retry on Throttling / RequestLimitExceeded / BotoCoreError
+        |  extract result_key (plain key or jq filter)
+        v
+   write output/<timestamp>/<region>/<service>-<function>.json
 ```
 
-### Component Details
+`main` reads the scan file from a local path or, when the value starts with `http://` or `https://`, fetches it over HTTP. If you do not pass `--regions`, it calls `ec2:DescribeRegions` and scans every Region whose opt-in status is `opt-in-not-required` or `opted-in`.
 
-#### 1. Configuration Layer
-- **Unified Configuration Format**: Support both YAML and JSON configuration formats
-- **Configuration Validator**: Ensure configurations are valid regardless of format
-- **Configuration Converter**: Allow conversion between formats
-- **Feature Parity**: Ensure all filtering and selection options are available in both formats
+### Concurrency
 
-#### 2. Core Scanning Engine
-- **AWS API Client**: Maintain the robust boto3 integration from the JSON implementation
-- **Multi-threading Manager**: Keep the concurrent scanning capabilities
-- **Organization Scanner**: Preserve the ability to scan across multiple accounts
-- **Retry & Throttling Handler**: Maintain the robust error handling and retry logic
-- **Resource Filter**: Implement the filtering capabilities from the Excel implementation
+Scanning runs on two nested thread pools. The outer pool processes Regions; the inner pool, created in `process_region`, processes the services within a Region. You bound each pool with `--concurrent-regions` and `--concurrent-services`. When a bound is not set, the pool uses its default worker count.
 
-#### 3. Output Processor
-- **Data Model**: Create a unified data model that can be serialized to both JSON and Excel
-- **JSON Output Generator**: Maintain the current JSON output functionality
-- **Excel Output Generator**: Add the Excel output capabilities
-- **Data Transformer**: Support operations like transposition for Excel output
+### Retry and throttling
 
-### Implementation Plan
+`api_call_with_retry` wraps each API call. On a `Throttling` or `RequestLimitExceeded` client error, or any `BotoCoreError`, it waits `retry_delay ** attempt` seconds and retries, up to `--max-retries` attempts. Other client errors are raised and logged, and that service is skipped for the Region.
 
-```mermaid
-gantt
-    title AWS Auto Inventory Unified Implementation
-    dateFormat  YYYY-MM-DD
-    section Architecture
-    Design Unified Architecture           :a1, 2025-06-10, 7d
-    Create Common Data Models             :a2, after a1, 5d
-    section Configuration
-    Implement Unified Config Parser       :b1, after a1, 10d
-    Add Configuration Validator           :b2, after b1, 5d
-    section Core Engine
-    Refactor Scanning Engine              :c1, after a2, 14d
-    Enhance Organization Scanner          :c2, after c1, 7d
-    Implement Advanced Filtering          :c3, after c1, 10d
-    section Output
-    Implement JSON Output Module          :d1, after c1, 5d
-    Implement Excel Output Module         :d2, after c1, 10d
-    Add Data Transformation Features      :d3, after d2, 7d
-    section Integration
-    Integration Testing                   :e1, after d1 d2 d3 c2 c3, 10d
-    Performance Optimization              :e2, after e1, 7d
-    Documentation                         :e3, after e2, 5d
+### Result extraction
+
+`_get_service_data` shapes each response based on `result_key`:
+
+- A `result_key` that starts with `.` is compiled as a `jq` filter and applied to the full response.
+- A plain `result_key` reads that top-level field from the response.
+- With no `result_key`, the full response is returned with `ResponseMetadata` removed.
+
+### Output
+
+Each result is written as `output/<timestamp>/<region>/<service>-<function>.json`. The run timestamp is fixed when the process starts, so all files from one run share a directory. A log file, `aws_resources_<timestamp>.log`, is written to the output directory.
+
+`DateTimeEncoder` serializes `datetime` values as ISO 8601 strings. There is no encoder for binary (`bytes`) values, so API operations that return binary data — such as `cloudtrail:ListPublicKeys` — can raise a serialization error. This is the cause of failures seen on some AWS GovCloud (US) scans.
+
+### Organization scanning
+
+`organization_scanner.py` runs from the management account:
+
+1. `get_organization_accounts` pages through `organizations:ListAccounts` and keeps accounts with status `ACTIVE`.
+2. `assume_role` calls `sts:AssumeRole` for `arn:aws:iam::<account-id>:role/<role-name>` to obtain a session in each account.
+3. `scan_organization` runs `scan.py`'s `main` against each account, writing results under `output/organization-<timestamp>/<account-id>/`.
+
+This lists accounts directly and does not walk the organizational unit (OU) tree, so OU structure does not affect which accounts are scanned.
+
+## In-progress implementation: aws_auto_inventory package
+
+The package reorganizes the same scanning logic into three layers. It is not yet complete.
+
+### Layers
+
+```text
+Configuration layer  -->  Core scanning engine  -->  Output processor (planned)
 ```
 
-## Detailed Implementation Strategy
+#### Configuration layer (`aws_auto_inventory/config/`)
 
-### 1. Refactor the Configuration System
+- `loader.py` (`ConfigLoader`) detects the file format from the extension and parses YAML or JSON into a `Config`.
+- `models.py` defines Pydantic models: `Config`, `Inventory`, `AWSConfig`, `Sheet`, and `ExcelConfig`. This schema differs from `scan.py`: each inventory holds an `aws` block, a list of `sheets` (one per API call), and an `excel` block.
+- `validator.py` (`ConfigValidator`) checks a loaded `Config` and returns a list of validation errors.
 
-Create a unified configuration system that supports both YAML and JSON formats:
+#### Core scanning engine (`aws_auto_inventory/core/`)
 
-```mermaid
-classDiagram
-    class ConfigLoader {
-        +load_config(path: str) : Config
-        -detect_format(path: str) : str
-    }
-    
-    class Config {
-        +inventories: List[Inventory]
-        +validate() : bool
-        +to_json() : str
-        +to_yaml() : str
-    }
-    
-    class Inventory {
-        +name: str
-        +aws: AWSConfig
-        +sheets: List[Sheet]
-        +excel: ExcelConfig
-    }
-    
-    class AWSConfig {
-        +profile: str
-        +region: List[str]
-        +organization: bool
-        +role_name: str
-    }
-    
-    class Sheet {
-        +name: str
-        +service: str
-        +function: str
-        +result_key: str
-        +parameters: dict
-    }
-    
-    class ExcelConfig {
-        +transpose: bool
-        +formatting: dict
-    }
-    
-    ConfigLoader --> Config : creates
-    Config --> Inventory : contains
-    Inventory --> AWSConfig : has
-    Inventory --> Sheet : has
-    Inventory --> ExcelConfig : has
-```
+- `scan_engine.py` (`ScanEngine`) iterates the inventories in a `Config`, dispatching each to an account scan or an organization scan and collecting `ScanResult` objects.
+- `region.py` (`RegionScanner`) scans the services in a Region concurrently with a thread pool.
+- `service.py` (`ServiceScanner`) scans one service through `AWSClient`. `ResourceFilter` in the same module is a placeholder that currently returns results unchanged.
+- `organization.py` (`OrganizationScanner`) lists active accounts with `organizations:ListAccounts` and assumes a role per account — the same approach as `organization_scanner.py`, with no OU traversal.
+- `aws_client.py` (`AWSClient`) calls AWS APIs with retry and result extraction, including the same plain-key and `jq`-filter handling as `scan.py`.
 
-### 2. Enhance the Core Scanning Engine
+#### Output processor (planned, not present)
 
-Refactor the scanning engine to maintain the multi-threading and organization scanning capabilities while adding the filtering features:
+`cli.py` imports `from .output.processor import OutputProcessor`, but the `aws_auto_inventory/output/` package does not exist in the repository. Because the import runs at module load, the `aws-auto-inventory` console script fails before it can scan or write output. JSON and Excel output generation remain to be implemented.
 
-```mermaid
-classDiagram
-    class ScanEngine {
-        +scan(config: Config) : ScanResult
-    }
-    
-    class AWSClient {
-        +call_api(service: str, function: str, params: dict) : dict
-        -handle_throttling(error: Exception, retry: int)
-    }
-    
-    class OrganizationScanner {
-        +scan_organization(config: Config) : List[AccountResult]
-        -assume_role(account_id: str, role_name: str) : Session
-    }
-    
-    class RegionScanner {
-        +scan_regions(config: Config, session: Session) : List[RegionResult]
-    }
-    
-    class ServiceScanner {
-        +scan_services(config: Config, session: Session, region: str) : List[ServiceResult]
-    }
-    
-    class ResourceFilter {
-        +apply_filters(results: dict, filters: dict) : dict
-    }
-    
-    ScanEngine --> OrganizationScanner : uses
-    ScanEngine --> RegionScanner : uses
-    RegionScanner --> ServiceScanner : uses
-    ServiceScanner --> AWSClient : uses
-    ServiceScanner --> ResourceFilter : uses
-```
+### Command-line interface (`aws_auto_inventory/cli.py`)
 
-### 3. Implement the Output Processor
+The CLI parses arguments (`--config`, `--output-dir`, `--format`, `--max-regions`, `--max-services`, `--max-retries`, `--retry-delay`, `--log-level`, `--validate-only`), loads and validates the configuration, checks credentials per inventory, runs the `ScanEngine`, and hands results to the output processor. The missing output module prevents the command from running end to end.
 
-Create a flexible output system that can generate both JSON and Excel outputs:
+### Configuration schema
 
-```mermaid
-classDiagram
-    class OutputProcessor {
-        +process(scan_result: ScanResult, format: str) : void
-    }
-    
-    class JSONOutputGenerator {
-        +generate(scan_result: ScanResult, path: str) : void
-    }
-    
-    class ExcelOutputGenerator {
-        +generate(scan_result: ScanResult, path: str) : void
-        -format_sheet(sheet: Sheet, data: dict) : void
-        -apply_transpose(data: dict, transpose: bool) : dict
-    }
-    
-    class DataTransformer {
-        +transform(data: dict, operations: List[str]) : dict
-    }
-    
-    OutputProcessor --> JSONOutputGenerator : uses
-    OutputProcessor --> ExcelOutputGenerator : uses
-    ExcelOutputGenerator --> DataTransformer : uses
-```
-
-## Implementation Details
-
-### Project Structure
-
-```
-aws-auto-inventory/
-├── aws_auto_inventory/
-│   ├── __init__.py
-│   ├── cli.py                  # Command-line interface
-│   ├── config/
-│   │   ├── __init__.py
-│   │   ├── loader.py           # Config loading (YAML/JSON)
-│   │   ├── validator.py        # Config validation
-│   │   └── models.py           # Config data models
-│   ├── core/
-│   │   ├── __init__.py
-│   │   ├── aws_client.py       # AWS API client with retry logic
-│   │   ├── scan_engine.py      # Main scanning engine
-│   │   ├── organization.py     # Organization scanning
-│   │   ├── region.py           # Region scanning
-│   │   ├── service.py          # Service scanning
-│   │   └── filter.py           # Resource filtering
-│   ├── output/
-│   │   ├── __init__.py
-│   │   ├── processor.py        # Output processing
-│   │   ├── json_generator.py   # JSON output
-│   │   ├── excel_generator.py  # Excel output
-│   │   └── transformer.py      # Data transformation
-│   └── utils/
-│       ├── __init__.py
-│       ├── logging.py          # Logging utilities
-│       └── threading.py        # Threading utilities
-├── tests/
-│   ├── __init__.py
-│   ├── conftest.py
-│   ├── test_config/
-│   ├── test_core/
-│   └── test_output/
-├── examples/
-│   ├── config_yaml_example.yaml
-│   ├── config_json_example.json
-│   └── README.md
-├── setup.py
-├── requirements.txt
-└── README.md
-```
-
-### Key Implementation Components
-
-#### 1. Configuration System
-
-The configuration system will support both YAML and JSON formats with automatic detection:
-
-```python
-# aws_auto_inventory/config/loader.py
-import yaml
-import json
-import os
-from .models import Config
-
-class ConfigLoader:
-    def load_config(self, path):
-        """Load configuration from file."""
-        format_type = self._detect_format(path)
-        
-        with open(path, 'r') as f:
-            if format_type == 'yaml':
-                config_data = yaml.safe_load(f)
-            else:  # json
-                config_data = json.load(f)
-        
-        return Config.from_dict(config_data)
-    
-    def _detect_format(self, path):
-        """Detect file format based on extension."""
-        _, ext = os.path.splitext(path)
-        if ext.lower() in ['.yaml', '.yml']:
-            return 'yaml'
-        return 'json'
-```
-
-Configuration data models will use Pydantic for validation:
-
-```python
-# aws_auto_inventory/config/models.py
-from pydantic import BaseModel, Field
-from typing import List, Dict, Optional, Union, Any
-
-class ExcelConfig(BaseModel):
-    transpose: bool = False
-    formatting: Dict[str, Any] = Field(default_factory=dict)
-
-class AWSConfig(BaseModel):
-    profile: Optional[str] = None
-    region: List[str] = Field(default_factory=lambda: ["us-east-1"])
-    organization: bool = False
-    role_name: str = "OrganizationAccountAccessRole"
-
-class Sheet(BaseModel):
-    name: str
-    service: str
-    function: str
-    result_key: Optional[str] = None
-    parameters: Dict[str, Any] = Field(default_factory=dict)
-
-class Inventory(BaseModel):
-    name: str
-    aws: AWSConfig = Field(default_factory=AWSConfig)
-    sheets: List[Sheet]
-    excel: ExcelConfig = Field(default_factory=ExcelConfig)
-
-class Config(BaseModel):
-    inventories: List[Inventory]
-    
-    def to_json(self):
-        """Convert config to JSON string."""
-        return self.json(indent=2)
-    
-    def to_yaml(self):
-        """Convert config to YAML string."""
-        import yaml
-        return yaml.dump(self.dict(), sort_keys=False)
-    
-    @classmethod
-    def from_dict(cls, data):
-        """Create config from dictionary."""
-        return cls(**data)
-```
-
-#### 2. Core Scanning Engine
-
-The core scanning engine will maintain the multi-threading and organization scanning capabilities:
-
-```python
-# aws_auto_inventory/core/scan_engine.py
-import concurrent.futures
-from ..config.models import Config, Inventory
-from .organization import OrganizationScanner
-from .region import RegionScanner
-
-class ScanEngine:
-    def __init__(self, max_workers_regions=None, max_workers_services=None):
-        self.max_workers_regions = max_workers_regions
-        self.max_workers_services = max_workers_services
-        self.organization_scanner = OrganizationScanner()
-        self.region_scanner = RegionScanner(max_workers=max_workers_services)
-    
-    def scan(self, config):
-        """Perform scanning based on configuration."""
-        results = []
-        
-        for inventory in config.inventories:
-            if inventory.aws.organization:
-                # Scan across organization
-                org_results = self.organization_scanner.scan_organization(
-                    inventory, self.region_scanner
-                )
-                results.append({
-                    "inventory_name": inventory.name,
-                    "organization_results": org_results
-                })
-            else:
-                # Scan single account
-                import boto3
-                session = boto3.Session(profile_name=inventory.aws.profile)
-                
-                # Scan regions concurrently
-                with concurrent.futures.ThreadPoolExecutor(
-                    max_workers=self.max_workers_regions
-                ) as executor:
-                    future_to_region = {
-                        executor.submit(
-                            self.region_scanner.scan_region,
-                            inventory, session, region
-                        ): region
-                        for region in inventory.aws.region
-                    }
-                    
-                    region_results = []
-                    for future in concurrent.futures.as_completed(future_to_region):
-                        region = future_to_region[future]
-                        try:
-                            result = future.result()
-                            region_results.append({
-                                "region": region,
-                                "services": result
-                            })
-                        except Exception as e:
-                            print(f"Error scanning region {region}: {e}")
-                
-                results.append({
-                    "inventory_name": inventory.name,
-                    "account_results": region_results
-                })
-        
-        return results
-```
-
-AWS API client with retry logic:
-
-```python
-# aws_auto_inventory/core/aws_client.py
-import time
-import boto3
-import botocore
-
-class AWSClient:
-    def __init__(self, session, max_retries=3, retry_delay=2):
-        self.session = session
-        self.max_retries = max_retries
-        self.retry_delay = retry_delay
-    
-    def call_api(self, service, function_name, region=None, parameters=None):
-        """Call AWS API with retry logic."""
-        client = self.session.client(service, region_name=region)
-        
-        for attempt in range(self.max_retries):
-            try:
-                function_to_call = getattr(client, function_name)
-                if parameters:
-                    return function_to_call(**parameters)
-                else:
-                    return function_to_call()
-            except botocore.exceptions.ClientError as error:
-                error_code = error.response["Error"]["Code"]
-                if error_code in ["Throttling", "RequestLimitExceeded"]:
-                    if attempt < (self.max_retries - 1):
-                        wait_time = self.retry_delay ** attempt
-                        time.sleep(wait_time)
-                        continue
-                raise
-            except botocore.exceptions.BotoCoreError:
-                if attempt < (self.max_retries - 1):
-                    wait_time = self.retry_delay ** attempt
-                    time.sleep(wait_time)
-                    continue
-                raise
-        
-        return None
-```
-
-#### 3. Output Processor
-
-The output processor will support both JSON and Excel formats:
-
-```python
-# aws_auto_inventory/output/processor.py
-from .json_generator import JSONOutputGenerator
-from .excel_generator import ExcelOutputGenerator
-
-class OutputProcessor:
-    def __init__(self):
-        self.json_generator = JSONOutputGenerator()
-        self.excel_generator = ExcelOutputGenerator()
-    
-    def process(self, scan_result, output_dir, formats=None):
-        """Process scan results and generate output files."""
-        if formats is None:
-            formats = ["json"]  # Default to JSON
-        
-        if "json" in formats:
-            self.json_generator.generate(scan_result, output_dir)
-        
-        if "excel" in formats:
-            self.excel_generator.generate(scan_result, output_dir)
-```
-
-Excel output generator:
-
-```python
-# aws_auto_inventory/output/excel_generator.py
-import os
-import pandas as pd
-from .transformer import DataTransformer
-
-class ExcelOutputGenerator:
-    def __init__(self):
-        self.transformer = DataTransformer()
-    
-    def generate(self, scan_result, output_dir):
-        """Generate Excel output from scan results."""
-        os.makedirs(output_dir, exist_ok=True)
-        
-        for inventory_result in scan_result:
-            inventory_name = inventory_result["inventory_name"]
-            excel_path = os.path.join(output_dir, f"{inventory_name}.xlsx")
-            
-            with pd.ExcelWriter(excel_path) as writer:
-                if "organization_results" in inventory_result:
-                    self._process_organization_results(
-                        inventory_result["organization_results"], writer
-                    )
-                elif "account_results" in inventory_result:
-                    self._process_account_results(
-                        inventory_result["account_results"], writer
-                    )
-    
-    def _process_organization_results(self, org_results, writer):
-        """Process organization results and write to Excel."""
-        for account_result in org_results:
-            account_id = account_result["account_id"]
-            for region_result in account_result["regions"]:
-                region = region_result["region"]
-                for service_result in region_result["services"]:
-                    sheet_name = f"{account_id}_{region}_{service_result['service']}"
-                    # Truncate sheet name if too long (Excel limitation)
-                    if len(sheet_name) > 31:
-                        sheet_name = sheet_name[:31]
-                    
-                    df = pd.json_normalize(service_result["result"])
-                    df.to_excel(writer, sheet_name=sheet_name)
-    
-    def _process_account_results(self, account_results, writer):
-        """Process account results and write to Excel."""
-        for region_result in account_results:
-            region = region_result["region"]
-            for service_result in region_result["services"]:
-                sheet_name = f"{region}_{service_result['service']}"
-                # Truncate sheet name if too long (Excel limitation)
-                if len(sheet_name) > 31:
-                    sheet_name = sheet_name[:31]
-                
-                df = pd.json_normalize(service_result["result"])
-                df.to_excel(writer, sheet_name=sheet_name)
-```
-
-#### 4. Command-Line Interface
-
-The CLI will provide a unified interface for all features:
-
-```python
-# aws_auto_inventory/cli.py
-import argparse
-import os
-import sys
-from .config.loader import ConfigLoader
-from .core.scan_engine import ScanEngine
-from .output.processor import OutputProcessor
-
-def main():
-    parser = argparse.ArgumentParser(
-        description="AWS Auto Inventory - Scan AWS resources and generate inventory"
-    )
-    parser.add_argument(
-        "-c", "--config", required=True,
-        help="Path to configuration file (YAML or JSON)"
-    )
-    parser.add_argument(
-        "-o", "--output-dir", default="output",
-        help="Directory to store output files"
-    )
-    parser.add_argument(
-        "-f", "--format", choices=["json", "excel", "both"], default="json",
-        help="Output format (default: json)"
-    )
-    parser.add_argument(
-        "--max-regions", type=int, default=None,
-        help="Maximum number of regions to scan concurrently"
-    )
-    parser.add_argument(
-        "--max-services", type=int, default=None,
-        help="Maximum number of services to scan concurrently per region"
-    )
-    parser.add_argument(
-        "--log-level", choices=["DEBUG", "INFO", "WARNING", "ERROR"], default="INFO",
-        help="Logging level"
-    )
-    
-    args = parser.parse_args()
-    
-    # Set up logging
-    import logging
-    logging.basicConfig(
-        level=getattr(logging, args.log_level),
-        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-    
-    # Load configuration
-    config_loader = ConfigLoader()
-    try:
-        config = config_loader.load_config(args.config)
-    except Exception as e:
-        print(f"Error loading configuration: {e}")
-        sys.exit(1)
-    
-    # Create output directory
-    os.makedirs(args.output_dir, exist_ok=True)
-    
-    # Determine output formats
-    formats = []
-    if args.format in ["json", "both"]:
-        formats.append("json")
-    if args.format in ["excel", "both"]:
-        formats.append("excel")
-    
-    # Run scan
-    scan_engine = ScanEngine(
-        max_workers_regions=args.max_regions,
-        max_workers_services=args.max_services
-    )
-    
-    try:
-        results = scan_engine.scan(config)
-    except Exception as e:
-        print(f"Error during scan: {e}")
-        sys.exit(1)
-    
-    # Process output
-    output_processor = OutputProcessor()
-    output_processor.process(results, args.output_dir, formats)
-    
-    print(f"Inventory completed successfully. Results stored in {args.output_dir}")
-
-if __name__ == "__main__":
-    main()
-```
-
-### Configuration Examples
-
-#### YAML Configuration Example
+The package configuration is an `inventories` list. Each inventory names an `aws` block, a `sheets` list, and an optional `excel` block.
 
 ```yaml
-# Example YAML configuration
 inventories:
   - name: my-aws-inventory
     aws:
@@ -668,6 +125,7 @@ inventories:
         - us-east-1
         - us-west-2
       organization: false
+      role_name: OrganizationAccountAccessRole
     excel:
       transpose: true
     sheets:
@@ -679,271 +137,12 @@ inventories:
         service: s3
         function: list_buckets
         result_key: Buckets
-      - name: IAMRoles
-        service: iam
-        function: list_roles
-        result_key: Roles
 ```
 
-#### JSON Configuration Example
+## Design decisions
 
-```json
-{
-  "inventories": [
-    {
-      "name": "my-aws-inventory",
-      "aws": {
-        "profile": "default",
-        "region": ["us-east-1", "us-west-2"],
-        "organization": false
-      },
-      "excel": {
-        "transpose": true
-      },
-      "sheets": [
-        {
-          "name": "EC2Instances",
-          "service": "ec2",
-          "function": "describe_instances",
-          "result_key": "Reservations"
-        },
-        {
-          "name": "S3Buckets",
-          "service": "s3",
-          "function": "list_buckets",
-          "result_key": "Buckets"
-        },
-        {
-          "name": "IAMRoles",
-          "service": "iam",
-          "function": "list_roles",
-          "result_key": "Roles"
-        }
-      ]
-    }
-  ]
-}
-```
-
-## Potential Challenges and Mitigation Strategies
-
-### 1. Backward Compatibility
-
-**Challenge**: Ensuring the new unified implementation remains compatible with existing configurations and workflows.
-
-**Mitigation Strategies**:
-- Implement configuration adapters that can convert between old and new formats
-- Provide clear migration guides and examples
-- Include backward compatibility layers that can process legacy configurations
-- Add deprecation warnings for legacy features that will be removed in future versions
-- Create automated migration tools to help users transition
-
-**Implementation Example**:
-```python
-def detect_legacy_config(config_path):
-    """Detect if a configuration file is in legacy format."""
-    with open(config_path, 'r') as f:
-        try:
-            if config_path.endswith('.json'):
-                config = json.load(f)
-                # Check for legacy JSON format indicators
-                return 'service' in config[0] and 'function' in config[0]
-            elif config_path.endswith('.yaml') or config_path.endswith('.yml'):
-                config = yaml.safe_load(f)
-                # Check for legacy YAML format indicators
-                return 'inventories' not in config and 'sheets' in config
-        except:
-            return False
-    return False
-
-def convert_legacy_config(config_path, output_path=None):
-    """Convert legacy configuration to new format."""
-    if output_path is None:
-        base, ext = os.path.splitext(config_path)
-        output_path = f"{base}_converted{ext}"
-    
-    # Implementation of conversion logic
-    # ...
-    
-    return output_path
-```
-
-### 2. Performance Considerations
-
-**Challenge**: Maintaining or improving performance while adding new features, especially for large AWS environments.
-
-**Mitigation Strategies**:
-- Implement efficient multi-threading with configurable thread pools
-- Use connection pooling for AWS API calls
-- Add caching mechanisms for frequently accessed data
-- Implement pagination for large result sets
-- Allow selective scanning of specific services/regions
-- Add progress reporting for long-running operations
-- Implement incremental scanning options
-
-**Implementation Example**:
-```python
-class CachingAWSClient:
-    def __init__(self, session, cache_ttl=300):
-        self.session = session
-        self.cache = {}
-        self.cache_ttl = cache_ttl
-        self.cache_timestamps = {}
-    
-    def call_api(self, service, function_name, region=None, parameters=None):
-        """Call AWS API with caching."""
-        cache_key = f"{service}:{function_name}:{region}:{json.dumps(parameters)}"
-        
-        # Check cache
-        current_time = time.time()
-        if cache_key in self.cache:
-            if current_time - self.cache_timestamps[cache_key] < self.cache_ttl:
-                return self.cache[cache_key]
-        
-        # Call API
-        result = self._make_api_call(service, function_name, region, parameters)
-        
-        # Update cache
-        self.cache[cache_key] = result
-        self.cache_timestamps[cache_key] = current_time
-        
-        return result
-    
-    def _make_api_call(self, service, function_name, region, parameters):
-        # Implementation of API call with retry logic
-        # ...
-```
-
-### 3. Error Handling and Edge Cases
-
-**Challenge**: Robust error handling for various AWS API errors, rate limiting, and edge cases.
-
-**Mitigation Strategies**:
-- Implement comprehensive error handling with specific error types
-- Add detailed logging for troubleshooting
-- Implement graceful degradation for non-critical failures
-- Add retry mechanisms with exponential backoff
-- Provide clear error messages and suggestions
-- Implement validation for all inputs and configurations
-
-**Implementation Example**:
-```python
-class AWSInventoryError(Exception):
-    """Base exception for AWS Auto Inventory."""
-    pass
-
-class ConfigurationError(AWSInventoryError):
-    """Error in configuration."""
-    pass
-
-class AWSAPIError(AWSInventoryError):
-    """Error in AWS API call."""
-    def __init__(self, service, function, error):
-        self.service = service
-        self.function = function
-        self.error = error
-        super().__init__(f"Error calling {service}.{function}: {error}")
-
-class ThrottlingError(AWSAPIError):
-    """AWS API throttling error."""
-    def __init__(self, service, function, retry_after=None):
-        self.retry_after = retry_after
-        super().__init__(service, function, "API throttling")
-
-# Error handling in API client
-def call_api_with_error_handling(client, service, function, parameters=None):
-    try:
-        # Make API call
-        # ...
-    except botocore.exceptions.ClientError as e:
-        error_code = e.response.get("Error", {}).get("Code", "")
-        if error_code == "Throttling":
-            retry_after = int(e.response.get("ResponseMetadata", {}).get("RetryAfter", 1))
-            raise ThrottlingError(service, function, retry_after)
-        elif error_code == "AccessDenied":
-            raise PermissionError(f"Access denied for {service}.{function}")
-        else:
-            raise AWSAPIError(service, function, str(e))
-    except Exception as e:
-        raise AWSAPIError(service, function, str(e))
-```
-
-### 4. Testing Strategy
-
-**Challenge**: Ensuring comprehensive testing of the unified implementation across different AWS environments.
-
-**Mitigation Strategies**:
-- Implement unit tests for all components
-- Use mocking for AWS services in tests
-- Implement integration tests for key workflows
-- Create test fixtures for different configuration scenarios
-- Implement CI/CD pipelines for automated testing
-- Add property-based testing for edge cases
-- Create a test matrix for different Python versions and dependencies
-
-**Implementation Example**:
-```python
-# tests/test_config/test_loader.py
-import pytest
-import tempfile
-import os
-from aws_auto_inventory.config.loader import ConfigLoader
-
-@pytest.fixture
-def yaml_config_file():
-    with tempfile.NamedTemporaryFile(suffix='.yaml', delete=False) as f:
-        f.write(b"""
-inventories:
-  - name: test-inventory
-    aws:
-      region:
-        - us-east-1
-    sheets:
-      - name: EC2
-        service: ec2
-        function: describe_instances
-""")
-    yield f.name
-    os.unlink(f.name)
-
-@pytest.fixture
-def json_config_file():
-    with tempfile.NamedTemporaryFile(suffix='.json', delete=False) as f:
-        f.write(b"""
-{
-  "inventories": [
-    {
-      "name": "test-inventory",
-      "aws": {
-        "region": ["us-east-1"]
-      },
-      "sheets": [
-        {
-          "name": "EC2",
-          "service": "ec2",
-          "function": "describe_instances"
-        }
-      ]
-    }
-  ]
-}
-""")
-    yield f.name
-    os.unlink(f.name)
-
-def test_load_yaml_config(yaml_config_file):
-    loader = ConfigLoader()
-    config = loader.load_config(yaml_config_file)
-    assert config.inventories[0].name == "test-inventory"
-    assert config.inventories[0].aws.region == ["us-east-1"]
-    assert config.inventories[0].sheets[0].name == "EC2"
-
-def test_load_json_config(json_config_file):
-    loader = ConfigLoader()
-    config = loader.load_config(json_config_file)
-    assert config.inventories[0].name == "test-inventory"
-    assert config.inventories[0].aws.region == ["us-east-1"]
-    assert config.inventories[0].sheets[0].name == "EC2"
-```
-
-### 5
+- **Scan files map directly to boto3 calls.** A scan entry is a service name, a client method, optional parameters, and an optional result key. This keeps the tool generic across every AWS service without per-service code.
+- **Concurrency is bounded but optional.** Region and service scanning use thread pools you can cap, trading throughput against API rate limits.
+- **Retries target rate limiting.** Backoff is applied to throttling and transient `BotoCoreError` conditions; other errors fail fast and are logged.
+- **Organization scanning is account-flat.** Accounts come from `organizations:ListAccounts`, not from OU traversal, so every active account is in scope regardless of OU placement.
+- **The package rewrite is layered.** Configuration, scanning, and output are separated so that YAML support, validation, and additional output formats can evolve independently. The output layer is the remaining gap.


### PR DESCRIPTION
## Summary

Rewrites the technical documentation to the shared AWS documentation style guide so this repo reads as one voice with the rest of the AWS OSS fleet. Voice is second person, present tense, active, task-oriented; headings are sentence case; the README follows the required section order. Docs are corrected to match what the code actually does today.

## Files changed

- **README.md** — Rewritten to the required README structure (Overview, Features, Prerequisites, Installation, Getting started, Usage, Configuration, Architecture, Contributing, Security, License). Documents the supported `scan.py` scanner: JSON scan-file list, `result_key` by plain key or `jq` filter, JSON output layout, URL scan files, and organization scanning. Corrects stale claims (see below).
- **aws-auto-inventory-unified-architecture.md** — Restyled as an ARCHITECTURE doc (components, data flow, concurrency, retries, design decisions). Covers both `scan.py` and the in-progress `aws_auto_inventory` package, and describes actual behavior rather than the previous aspirational design plan.

## Stale behavior corrected against source

- The previous README documented the `aws-auto-inventory` console script (YAML config, Excel output) as working. The packaged CLI imports `from .output.processor import OutputProcessor`, but `aws_auto_inventory/output/` does not exist, so the console script fails at import and cannot produce output today. The docs now present `scan.py` as the supported path and describe the package as in progress.
- Documented the `requests`/`jq` install gap: `scan.py` imports `requests`, which is not in `requirements.txt` or `setup.py`.
- Documented the binary-data serialization limitation: there is no `bytes` encoder, so operations such as `cloudtrail:ListPublicKeys` can fail to serialize (affects some AWS GovCloud (US) scans).
- Clarified that organization scanning lists accounts via `organizations:ListAccounts` and does not traverse organizational units (OUs).

## Compliance

Compliance files (LICENSE, NOTICE, SECURITY.md, CODE_OF_CONDUCT.md, CONTRIBUTING.md, CHANGELOG.md) were not modified. No branch protections or settings were changed.
